### PR TITLE
chore(deps): bump vue-music-flow to v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.16.2",
-        "vue-music-flow": "^1.0.0"
+        "vue-music-flow": "^1.0.1"
       },
       "devDependencies": {
         "@nuxt/devtools": "^2.1.3",
@@ -17571,9 +17571,9 @@
       }
     },
     "node_modules/vue-music-flow": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/vue-music-flow/-/vue-music-flow-1.0.0.tgz",
-      "integrity": "sha512-R/FekVjolUf5Rp9hjhlG3lk9axQc7KSxIkid4q0olARsnC534izH1RTCT7GJfLVUnIapSXa4lW5f9kOJFeusTw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vue-music-flow/-/vue-music-flow-1.0.1.tgz",
+      "integrity": "sha512-phpqh0R8oxQiMrFlW07Q613zvg5XBXct6EtUXSanHUl4sAV0adnoqrnJ6yL5Ltj8A+uaJaM1asMcVBSZqoyXYA==",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@nuxt/kit": "^3.16.2",
-    "vue-music-flow": "^1.0.0"
+    "vue-music-flow": "^1.0.1"
   },
   "devDependencies": {
     "@nuxt/devtools": "^2.1.3",


### PR DESCRIPTION
Upgraded vue-music-flow dependency from v1.0.0 to v1.0.1 in package.json and package-lock.json. This ensures compatibility with the latest fixes and improvements provided by the library.